### PR TITLE
Switch free Helvetica alternative to Liberation Sans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
       freetype \
       harfbuzz \
       ca-certificates \
-      ttf-freefont \
+      ttf-liberation \
       nodejs \
       yarn
 


### PR DESCRIPTION
Helvetica isn't a freely licensed font, so we need to use a free alternative. We used to use Liberation Sans, but switched to Free Sans when we moved to Alpine last November.

We've since had complaints from users that the Xerox scanners used to print and send letters have problems reading addresses, for example translating `fi` as `??`. This is because Free Sans places the letters too close together.

This PR returns our Helvetica-alternative to Liberation Sans, to reinstate compatibility with Sirius Xerox scanners.

#minor