### PR TITLE
Specify major version of github-pages-deploy-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           yarn install
           yarn run redoc:build
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.3.4
+        uses: JamesIves/github-pages-deploy-action@4
         with:
           branch: gh-pages
           folder: openapi/docs


### PR DESCRIPTION
github-pages-deploy-action specific minor version breaks, have set this to now use the major version so it publishes the OpenAPI spec correctly