### PR TITLE
Add missing `v` for action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           yarn install
           yarn run redoc:build
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: openapi/docs


### PR DESCRIPTION
The action `JamesIves/github-pages-deploy-action@4` was missing a `v` before the version number causing the documents to not get built.