### PR TITLE
Prevent dependabot PR error unable to publish test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,72 +16,21 @@ defaults:
 jobs:
   test:
     name: Test PDF Service
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
+    uses: ./.github/workflows/test_job.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Dependencies from Cache
-        uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Run Javascript Linting
-        run: |
-          make lint-test
-
-      - name: Run Unit Tests & Generate Coverage Report
-        run: |
-          mkdir -p /home/runner/project/build/service-pdf
-          make unit-test-coverage
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always() && ${{ github.actor != 'dependabot[bot]' }}
-        with:
-          check_name: "Unit Test Results"
-          files: test-results/junit/results.xml
-
-      - name: Run SonarQube
-        uses: sonarsource/sonarqube-scan-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
-      - name: Coverage Report
-        uses: lucassabreu/comment-coverage-clover@main
-        with:
-          file: "coverage/clover.xml"
-          min-line-coverage: 89
-          min-method-coverage: 100
-
-      - name: Upload Junit
-        uses: actions/upload-artifact@v3
-        with:
-          name: junit
-          path: |
-            test-results/junit
-
-      - name: Upload Coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: |
-            /home/runner/project/build/service-pdf
+  publish_unit_tests:
+    name: Publish Unit Tests
+    needs: ['test']
+    uses: ./.github/workflows/publish_unit_tests_job.yml
 
   build:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
-    needs: test
+    if: github.actor != 'dependabot[bot]'
+    needs: ['publish_unit_tests']
     outputs:
       tag: ${{ steps.bump_version.outputs.tag }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ jobs:
   test:
     name: Test PDF Service
     uses: ./.github/workflows/test_job.yml
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
   publish_unit_tests:
     name: Publish Unit Tests
     needs: ['test']
     uses: ./.github/workflows/publish_unit_tests_job.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
   build:
     name: "Build & Push Containers"

--- a/.github/workflows/publish_unit_tests_job.yml
+++ b/.github/workflows/publish_unit_tests_job.yml
@@ -1,0 +1,37 @@
+on:
+  workflow_call:
+
+jobs:
+  publish_unit_tests:
+    name: Publish Unit Tests
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+
+    steps:
+      - name: Download Junit
+        id: download_junit
+        uses: actions/download-artifact@v3
+        with:
+          name: junit
+          path: test-results/junit
+
+      - name: Download Coverage
+        id: download_coverage
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+          path: coverage
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          check_name: "Unit Test Results"
+          files: test-results/junit/results.xml
+
+      - name: Coverage Report
+        uses: lucassabreu/comment-coverage-clover@main
+        with:
+          file: "/home/runner/work/opg-pdf-service/opg-pdf-service/coverage/clover.xml"
+          min-line-coverage: 89
+          min-method-coverage: 100

--- a/.github/workflows/publish_unit_tests_job.yml
+++ b/.github/workflows/publish_unit_tests_job.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
+      SONAR_HOST_URL:
+        required: true
 
 jobs:
   publish_unit_tests:
@@ -35,3 +40,9 @@ jobs:
           file: "/home/runner/work/opg-pdf-service/opg-pdf-service/coverage/clover.xml"
           min-line-coverage: 89
           min-method-coverage: 100
+
+      - name: Run SonarQube
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/publish_unit_tests_job.yml
+++ b/.github/workflows/publish_unit_tests_job.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
 
     steps:
+      - uses: actions/checkout@v3
       - name: Download Junit
         id: download_junit
         uses: actions/download-artifact@v3

--- a/.github/workflows/test_job.yml
+++ b/.github/workflows/test_job.yml
@@ -1,10 +1,5 @@
 on:
   workflow_call:
-    secrets:
-      SONAR_TOKEN:
-        required: true
-      SONAR_HOST_URL:
-        required: true
 
 jobs:
   test:
@@ -36,12 +31,6 @@ jobs:
         run: |
           mkdir -p /home/runner/project/build/service-pdf
           make unit-test-coverage
-
-      - name: Run SonarQube
-        uses: sonarsource/sonarqube-scan-action@master
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
       - name: Upload Junit
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test_job.yml
+++ b/.github/workflows/test_job.yml
@@ -1,0 +1,58 @@
+on:
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
+      SONAR_HOST_URL:
+        required: true
+
+jobs:
+  test:
+    name: Test PDF Service
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Dependencies from Cache
+        uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Run Javascript Linting
+        run: |
+          make lint-test
+
+      - name: Run Unit Tests & Generate Coverage Report
+        run: |
+          mkdir -p /home/runner/project/build/service-pdf
+          make unit-test-coverage
+
+      - name: Run SonarQube
+        uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+
+      - name: Upload Junit
+        uses: actions/upload-artifact@v3
+        with:
+          name: junit
+          path: |
+            test-results/junit
+
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: |
+            coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
       yarn
 
 RUN apk update && \
+    apk upgrade busybox --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main && \
     apk upgrade \
     libssl1.1 \
     libcrypto1.1 && \


### PR DESCRIPTION
When creating PRs, dpendabot lacks permission to publish unit test results. It also would build and push containers if tests pass.

Example: https://github.com/ministryofjustice/opg-pdf-service/runs/7389544087?check_suite_focus=true

We don't require publishing test coverage on dependabot prs, just that they passed.
We also don't require the building and publishing of containers.

This PR should now allow the PRs to be correctly tested rather than every one throwing an error.

Also fixes busybox and lls_client vulnerabilities

### Before
![image](https://user-images.githubusercontent.com/5390820/179757993-9bc4a678-36c1-495c-a64d-36f3d0f4aacf.png)

### After
![image](https://user-images.githubusercontent.com/5390820/179758677-9a291b1a-1f97-4e97-9b97-0394b528d7b5.png)
 