### PR TITLE
Build and push after test not result publication

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   build:
     name: "Build & Push Containers"
     runs-on: ubuntu-latest
-    needs: ['publish_unit_tests']
+    needs: ['test']
     outputs:
       tag: ${{ steps.bump_version.outputs.tag }}
     steps:


### PR DESCRIPTION
Dependabot does not have permissions for publishing so cannot trigger the build step