### PR TITLE
Replace ::set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/test_job.yml
+++ b/.github/workflows/test_job.yml
@@ -13,7 +13,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Dependencies from Cache
         uses: actions/cache@v3
         id: yarn-cache


### PR DESCRIPTION
[GitHub have deprecated ::set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

VEGA-1518 #patch