### PR TITLE
Enable lockFileMaintenance for Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
         "config:base",
         "schedule:earlyMondays"
     ],
+    "lockFileMaintenance": { "enabled": true },
     "packageRules": [
         {
             "automerge": true,


### PR DESCRIPTION
So that it keeps indirect dependencies up-to-date

#patch