### PR TITLE
SP-1426 - Patch PDF Service #minor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Test & Build
 
 on:
+  schedule:
+    - cron: "00 10 * * 1"
   pull_request:
     branches:
       - main
@@ -56,14 +58,13 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: pdf-service:latest-amd64
-          severity: 'HIGH,CRITICAL'
           format: 'template'
           template: '@/contrib/sarif.tpl'
           output: 'trivy-results-amd64.sarif'
 
       - name: Upload Trivy scan results for amd64 image to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
-        if: ${{ always() && github.actor != 'dependabot[bot]' }}
+        if: always()
         with:
           sarif_file: 'trivy-results-amd64.sarif'
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# Ignore Yarn DevDependency
+CVE-2022-33987

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,6 @@ RUN apk add --no-cache \
       nodejs \
       yarn
 
-RUN apk update && \
-    apk upgrade busybox --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main && \
-    apk upgrade \
-    libssl1.1 \
-    libcrypto1.1 && \
-    rm -rf /var/cache/apk/*
-
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ build-test:
 	docker-compose build yarn
 
 scan:
-	trivy image --exit-code 0 --severity MEDIUM,HIGH pdf-service:latest
-	trivy image --exit-code 1 --severity CRITICAL pdf-service:latest
+	trivy image pdf-service:latest-amd64
 
 unit-test: setup-directories
 	docker-compose run --rm yarn unit-test

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,9 +2473,9 @@ convert-source-map@^2.0.0:
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
 cookiejar@^2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.3.tgz#fc7a6216e408e74414b90230050842dacda75acc"
-  integrity sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
+  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 core-js-compat@^3.25.1:
   version "3.25.2"


### PR DESCRIPTION
- SP-1426 - Patch cookiejar dev package #patch
- SP-1426 - Tighten trivy scan, and add weekly build #minor
- SP-1426 - Remove manual patching of old vulnerabilities #minor
- SP-1426 - Ignore trivy dev dependency vulnerability as not in final image, just in lock file #minor
