### PR TITLE
Extend the wait time before attempting to run inspec tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-test:
 
 test-image: setup-directories
 	docker run --rm -d --name pdf-service pdf-service:latest-amd64
-	sleep 2
+	sleep 10
 	inspec exec inspec -t docker://pdf-service --reporter cli junit:test-results/junit/pdf-service-inspec.xml
 	docker container kill pdf-service
 


### PR DESCRIPTION
It looks as if 2 seconds is not long enough for the container come up.

Note that I tried to solve this properly by putting a test into inspec to check whether the socket is ready to receive connections. However, the problem with this is that inspec does not support retries natively; and because we are accessing the application via docker (and not over HTTP), trying to use the socket library doesn't work, e.g. something like this:

```
control 'Port' do
  title 'Port should be ready'
  desc 'Test that the port is available, with retries'

  describe 'PDF service' do
    it('should have an open TCP port') do
      port_is_open = false
      tries = 0

      while (not port_is_open) and (tries < 10)
        port_is_open = Socket.tcp('localhost', '80', connect_timeout: 5) { true } rescue false

        if (port_is_open)
          break
        end

        tries += 1
        sleep(1)
      end

      expect(port_is_open).to eq true
    end
  end
end
```

never sets `port_is_open` to true.

While this (using inspec methods, providing the service is up) does work:

```
describe port(80) do
  it { should be_listening }
end
```

What I really wanted to do was the latter, but with a retry; but the inspec developers have no intention of adding retries: https://github.com/inspec/inspec/issues/1404

So it looks like the only option (without loads of work figuring out how to get Ruby's `socket` to connect to a port when inspec is accessing an image via a docker:// URL) is to extend the wait time.