### PR TITLE
Stop doing lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
         "schedule:earlyMondays"
     ],
     "branchPrefix": "renovate-",
-    "lockFileMaintenance": { "enabled": true },
     "packageRules": [
         {
             "automerge": true,


### PR DESCRIPTION
We don't need to non-security updates to our transitive dependencies

#minor 