### PR TITLE
VEGA-2248 Fix trivy issue preventing renovate upgrade #minor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,6 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: pdf-service:latest-amd64
-          format: 'template'
           exit-code: '1'
           ignore-unfixed: true
           format: 'sarif'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
           format: 'template'
           exit-code: '1'
           ignore-unfixed: true
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results-amd64.sarif'
 
       - name: Upload Trivy scan results for amd64 image to GitHub Security tab


### PR DESCRIPTION
Errors in the CI build at the trivy scan step suggest that the warning being thrown out is breaking the build. This fixes a deprecated trivy flag.