### PR TITLE
SW-7058 Attempt to fix build by increasing sleep after start-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-test-image: setup-directories start-container run-load stop-container
 
 start-container:
 	docker run --cpus=0.5 --memory=1G -p 8000:80 --rm -d --name pdf-service pdf-service:latest-amd64
-	sleep 2
+	sleep 4
 
 stop-container:
 	docker container kill pdf-service

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ load-test-image: setup-directories start-container run-load stop-container
 
 start-container:
 	docker run --cpus=0.5 --memory=1G -p 8000:80 --rm -d --name pdf-service pdf-service:latest-amd64
-	sleep 4
+	sleep 8
 
 stop-container:
 	docker container kill pdf-service


### PR DESCRIPTION
Temporarily increase the value of sleep after start-container, in attempt to fix failing build on main when running load test